### PR TITLE
Authenticate via netrc, not -u/-p on the command line (#30)

### DIFF
--- a/internal/sync/executor.go
+++ b/internal/sync/executor.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -45,13 +48,30 @@ func (e *Executor) Run(ctx context.Context) (*daemon.SyncResult, error) {
 		return result, result.Error
 	}
 
-	args := e.buildArgs(password)
+	// Authenticate via a temporary netrc rather than -u/-p on the command
+	// line (Refs #30): argv is world-readable via /proc/<pid>/cmdline, so a
+	// -p password is visible to any local process for the whole sync. The
+	// netrc lives 0600 in a 0700 dir and is removed when the sync returns.
+	netrcHome, cleanup, err := e.writeNetrc(password)
+	if err != nil {
+		result.Error = fmt.Errorf("preparing netrc: %w", err)
+		result.Duration = time.Since(result.StartTime)
+		result.ExitCode = -1
+		return result, result.Error
+	}
+	defer cleanup()
+
+	args := e.buildArgs()
 
 	timeout := e.cfg.Sync.Timeout.Duration
 	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(cmdCtx, e.cfg.Sync.NextcloudCmd, args...)
+
+	// Point HOME at the temp netrc dir so `nextcloudcmd -n` reads our
+	// credentials there, not the daemon user's real ~/.netrc.
+	cmd.Env = envWithHome(netrcHome)
 
 	// Kernel-level orphan prevention (Refs #27):
 	//   Pdeathsig: SIGKILL — Linux kernel sends SIGKILL to this child if the
@@ -118,19 +138,69 @@ func (e *Executor) Run(ctx context.Context) (*daemon.SyncResult, error) {
 	return result, nil
 }
 
-// buildArgs constructs the nextcloudcmd argument list.
-func (e *Executor) buildArgs(password string) []string {
+// buildArgs constructs the nextcloudcmd argument list. Credentials are NOT
+// passed here — `-n` makes nextcloudcmd read them from the netrc under the
+// HOME we set on the command's environment (Refs #30). Nothing secret, and
+// no username, reaches argv.
+func (e *Executor) buildArgs() []string {
 	var args []string
 
 	args = append(args, e.cfg.Sync.ExtraArgs...)
 	args = append(args, "--non-interactive")
-	args = append(args, "-u", e.cfg.Server.Username)
-	args = append(args, "-p", password)
+	args = append(args, "-n")
 	args = append(args, "--path", e.cfg.Sync.RemotePath)
 	args = append(args, e.cfg.Sync.LocalDir)
 	args = append(args, e.cfg.Server.URL)
 
 	return args
+}
+
+// writeNetrc creates a temporary directory (0700) holding a .netrc (0600)
+// with the server credentials, for `nextcloudcmd -n`. Returns the directory
+// to use as HOME and a cleanup func the caller must defer. Keeping the
+// password in a private file instead of on argv is the whole point of #30.
+func (e *Executor) writeNetrc(password string) (string, func(), error) {
+	u, err := url.Parse(e.cfg.Server.URL)
+	if err != nil {
+		return "", nil, fmt.Errorf("parsing server URL %q: %w", e.cfg.Server.URL, err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", nil, fmt.Errorf("server URL %q has no host", e.cfg.Server.URL)
+	}
+
+	dir, err := os.MkdirTemp("", "nsd-netrc-")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating netrc temp dir: %w", err)
+	}
+	cleanup := func() {
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			e.logger.Warn("failed to remove netrc temp dir", "dir", dir, "error", rmErr)
+		}
+	}
+
+	// machine line matches the server host; nextcloudcmd looks up login/password by host.
+	content := fmt.Sprintf("machine %s login %s password %s\n", host, e.cfg.Server.Username, password)
+	if err := os.WriteFile(filepath.Join(dir, ".netrc"), []byte(content), 0o600); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("writing netrc: %w", err)
+	}
+
+	return dir, cleanup, nil
+}
+
+// envWithHome returns the current environment with HOME replaced by the given
+// path, so a child process reads netrc/config from there.
+func envWithHome(home string) []string {
+	base := os.Environ()
+	out := make([]string, 0, len(base)+1)
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "HOME=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "HOME="+home)
 }
 
 // CheckNextcloudCmd verifies that nextcloudcmd is available.

--- a/internal/sync/executor_test.go
+++ b/internal/sync/executor_test.go
@@ -202,13 +202,12 @@ func TestBuildArgs(t *testing.T) {
 	cfg.Sync.ExtraArgs = []string{"--silent"}
 
 	executor := NewExecutor(cfg, quietLogger())
-	args := executor.buildArgs("my-password")
+	args := executor.buildArgs()
 
 	expected := []string{
 		"--silent",
 		"--non-interactive",
-		"-u", "alice",
-		"-p", "my-password",
+		"-n",
 		"--path", "/alice",
 		"/home/alice/nextcloud",
 		"https://cloud.example.com",
@@ -223,6 +222,13 @@ func TestBuildArgs(t *testing.T) {
 			t.Errorf("args[%d] = %q, want %q", i, arg, expected[i])
 		}
 	}
+
+	// Refs #30: no credential — and no username — may appear on argv.
+	for _, arg := range args {
+		if arg == "-p" || arg == "-u" || arg == "my-password" || arg == "alice" {
+			t.Errorf("argv leaks credential/username: found %q in %v", arg, args)
+		}
+	}
 }
 
 func TestBuildArgsNoExtras(t *testing.T) {
@@ -230,10 +236,70 @@ func TestBuildArgsNoExtras(t *testing.T) {
 	cfg.Sync.ExtraArgs = nil
 
 	executor := NewExecutor(cfg, quietLogger())
-	args := executor.buildArgs("pw")
+	args := executor.buildArgs()
 
 	if args[0] != "--non-interactive" {
 		t.Errorf("first arg = %q, want --non-interactive", args[0])
+	}
+}
+
+func TestWriteNetrc(t *testing.T) {
+	cfg := testConfig(t, "nextcloudcmd")
+	executor := NewExecutor(cfg, quietLogger())
+
+	dir, cleanup, err := executor.writeNetrc("s3cr3t-pw")
+	if err != nil {
+		t.Fatalf("writeNetrc: %v", err)
+	}
+	defer cleanup()
+
+	// Directory must be private (0700).
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := di.Mode().Perm(); perm != 0o700 {
+		t.Errorf("netrc dir mode = %o, want 700", perm)
+	}
+
+	// .netrc must be 0600 and contain host/login/password.
+	path := filepath.Join(dir, ".netrc")
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat .netrc: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf(".netrc mode = %o, want 600", perm)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read .netrc: %v", err)
+	}
+	want := "machine cloud.example.com login alice password s3cr3t-pw\n"
+	if string(body) != want {
+		t.Errorf(".netrc = %q, want %q", string(body), want)
+	}
+
+	// Cleanup must remove the directory.
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("temp dir still present after cleanup: %v", err)
+	}
+}
+
+func TestEnvWithHome(t *testing.T) {
+	env := envWithHome("/tmp/netrc-home")
+	var homeCount int
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HOME=") {
+			homeCount++
+			if kv != "HOME=/tmp/netrc-home" {
+				t.Errorf("HOME = %q, want HOME=/tmp/netrc-home", kv)
+			}
+		}
+	}
+	if homeCount != 1 {
+		t.Errorf("HOME appears %d times, want exactly 1", homeCount)
 	}
 }
 


### PR DESCRIPTION
Closes #30.

## Problem

The executor invoked `nextcloudcmd` with `-u <user> -p <password>` on the command line. argv is world-readable via `/proc/<pid>/cmdline` (`ps`, `pgrep -a`), so the password was visible to any local process or user for the full duration of every sync — defeating the point of the 0600 password_file.

## Fix

- Write credentials to a `.netrc` (0600) inside a per-run temp dir (0700).
- Point the child's `HOME` at that dir and invoke `nextcloudcmd -n`.
- Both password **and** username leave argv.
- Temp dir removed when the sync returns (deferred cleanup; also logged if removal fails).

## Verification

- `go test ./...` green.
- New tests: argv carries no `-p`/`-u`/password/username; netrc is 0600 in a 0700 dir with the right `machine/login/password`; `HOME` override appears exactly once.
- Smoke-tested against a live Nextcloud 30 server: `nextcloudcmd -n` with a temp netrc authenticated successfully (user API returned OK, no 401).

## Acceptance (issue #30)

1. ✅ `ps`/`pgrep -a` during a sync shows no password on the `nextcloudcmd` line
2. ✅ Auth still works (verified live)
3. ✅ Temp netrc is 0600, in a 0700 dir, removed on completion