### PR TITLE
Package a .deb via nfpms on every release (#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ POST-COMPACT-CONTEXT-*.md
 nsd-*
 nextcloud-sync-daemon-*
 build/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,33 @@ builds:
       - -s -w -X main.version={{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
 
 changelog:
   sort: asc
+
+nfpms:
+  - package_name: nextcloud-sync-daemon
+    vendor: Graeme Ross
+    homepage: https://github.com/graemejross/nextcloud-sync-daemon
+    maintainer: Graeme Ross <graeme@graemejross.com>
+    description: |-
+      Event-driven sync daemon for headless Nextcloud clients.
+      Wraps nextcloudcmd with filesystem watching, notify_push WebSocket,
+      webhook and polling triggers, peer notification and a health endpoint.
+    license: MIT
+    section: net
+    formats:
+      - deb
+    bindir: /usr/bin
+    dependencies:
+      - nextcloud-desktop-cmd
+    contents:
+      - src: examples/config.yaml
+        dst: /etc/nextcloud-sync-daemon/config.yaml.example
+      - src: packaging/nextcloud-sync-daemon.service
+        dst: /usr/lib/systemd/system/nextcloud-sync-daemon.service
+      - src: examples/nextcloud-sync-daemon.service
+        dst: /usr/share/doc/nextcloud-sync-daemon/examples/nextcloud-sync-daemon.service
+      - src: README.md
+        dst: /usr/share/doc/nextcloud-sync-daemon/README.md

--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ Event-driven sync daemon for headless Nextcloud servers. Wraps `nextcloudcmd` wi
 
 ## Installation
 
+### Debian / Ubuntu package
+
+`.deb` packages for amd64 and arm64 are available from [GitHub Releases](https://github.com/graemejross/nextcloud-sync-daemon/releases):
+
+```bash
+sudo apt install ./nextcloud-sync-daemon_*.deb
+```
+
+The package installs the binary to `/usr/bin`, an example config to `/etc/nextcloud-sync-daemon/config.yaml.example`, and a systemd unit (not enabled). First run:
+
+```bash
+sudo cp /etc/nextcloud-sync-daemon/config.yaml.example /etc/nextcloud-sync-daemon/config.yaml
+sudo nano /etc/nextcloud-sync-daemon/config.yaml   # set server, credentials, local_dir
+sudo systemctl edit nextcloud-sync-daemon          # add: [Service] ReadWritePaths=/path/to/sync-dir
+sudo systemctl enable --now nextcloud-sync-daemon
+```
+
+The `ReadWritePaths` drop-in is required because the unit runs with `ProtectSystem=strict`; without it the daemon exits at startup reporting the sync directory is not writable.
+
+The package depends on `nextcloud-desktop-cmd`, which provides `nextcloudcmd`.
+
 ### Download
 
 Pre-built binaries for `linux/amd64` and `linux/arm64` are available from [GitHub Releases](https://github.com/graemejross/nextcloud-sync-daemon/releases).

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -19,12 +19,11 @@ server:
   #   chmod 600 /etc/nextcloud-sync-daemon/password
   # The daemon warns at startup if the file is readable by group/others.
   #
-  # NOTE: The password is passed as a command-line argument to nextcloudcmd,
-  # which means it is visible via 'ps' to other users on the system.
-  # Mitigations:
+  # The daemon passes credentials to nextcloudcmd via a temporary 0600 .netrc,
+  # not on the command line, so the password does not appear in the process
+  # list (since v0.4.0). Still recommended:
   #   - Use a Nextcloud app password (limited scope) instead of the main password
   #   - Run the daemon as a dedicated user
-  #   - Use ProtectProc=invisible in the systemd unit (hides /proc from other users)
 
 sync:
   # Local directory to sync (required)

--- a/packaging/nextcloud-sync-daemon.service
+++ b/packaging/nextcloud-sync-daemon.service
@@ -1,0 +1,52 @@
+# System-scope systemd unit shipped in the .deb package.
+# The example unit in examples/ documents both system and user scope;
+# this one is fixed to the packaged paths (/usr/bin, /etc).
+#
+# Before enabling:
+#   1. cp /etc/nextcloud-sync-daemon/config.yaml.example /etc/nextcloud-sync-daemon/config.yaml
+#      and edit it for your server.
+#   2. Grant the daemon write access to your sync directory with a drop-in:
+#        systemctl edit nextcloud-sync-daemon
+#      and add:
+#        [Service]
+#        ReadWritePaths=/path/to/your/sync-dir
+#      Without this, ProtectSystem=strict leaves the filesystem read-only and
+#      the daemon exits at startup with a "local_dir not writable" config error.
+#   3. systemctl enable --now nextcloud-sync-daemon
+
+[Unit]
+Description=Nextcloud Sync Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# Type=notify: daemon signals readiness after config validation and source startup
+Type=notify
+
+# Belt-and-braces: kill any orphan nextcloudcmd before starting (Refs #27).
+# The daemon's Pdeathsig handles orphans at the kernel level, but if a user
+# manually started nextcloudcmd outside the daemon this catches it too.
+ExecStartPre=-/usr/bin/pkill -f nextcloudcmd
+
+ExecStart=/usr/bin/nextcloud-sync-daemon --config /etc/nextcloud-sync-daemon/config.yaml
+
+# Restart on failure with 5-second delay
+Restart=on-failure
+RestartSec=5
+
+# Watchdog: daemon sends heartbeats every WatchdogSec/2 from a goroutine that
+# runs independently of sync work, so a slow sync does not miss its window.
+WatchdogSec=1800
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+# Hide /proc entries from other users (systemd 247+). Defence in depth:
+# since v0.4.0 credentials are passed via .netrc, not the command line,
+# but this also hides paths and server URL from other users.
+ProtectProc=invisible
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds an `nfpms` section to `.goreleaser.yml` so every tag push publishes `.deb` packages for amd64 and arm64 alongside the existing tarballs.

Closes #34's core ask. Departures from the issue as filed, per the discussion there:

- `/usr/bin`, not `/opt` + symlink into `/usr/local/bin` — Debian policy reserves `/usr/local` for the local admin.
- Depends on `nextcloud-desktop-cmd` only. The binary is statically linked, so `golang` is not a runtime dependency.

Contents: binary, `config.yaml.example` under `/etc/nextcloud-sync-daemon/`, a packaging-specific system unit (shipped disabled, `ProtectSystem=strict`, header documents the `ReadWritePaths` drop-in), README + the dual-scope example unit under `/usr/share/doc`. README gains a Debian install section.

Also corrects the example-config note that still claimed the password is passed on `nextcloudcmd`'s argv (stale since #30 / v0.4.0), and migrates `archives.format` → `formats` (goreleaser deprecation).

## Verification

- `goreleaser check` passes; snapshot build produces both `.deb`s with no deprecation warnings.
- `dpkg-deb -I`: control fields as intended (Depends: nextcloud-desktop-cmd, Section: net).
- `dpkg-deb -c`: layout as above, 0755 binary.
- Extracted binary runs and prints its version.
- `systemd-analyze verify` on the packaged unit: clean apart from the binary path not existing on the build host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqHttn5PvNJ5MejyzABLJa