### PR TITLE
Add --init-enable / --init-disable systemd registration (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,26 @@ Without `--once`, the daemon runs continuously, syncing on events from enabled s
 
 ## Running as a systemd service
 
+### `--init-enable` (recommended)
+
+With a valid config in place, the daemon can register itself:
+
+```bash
+nextcloud-sync-daemon --init-enable          # user scope
+sudo nextcloud-sync-daemon --init-enable     # system scope (run as root)
+```
+
+Run as root it writes a system unit to `/etc/systemd/system/` and runs `systemctl enable --now`; run as a normal user it writes a user unit to `~/.config/systemd/user/` and enables it with `systemctl --user`. The generated unit embeds the paths to the binary and the config file it was invoked with, and (system scope) grants write access to the configured sync directory, so no editing is needed. It validates the config first and refuses to overwrite an existing unit.
+
+`--init-disable` stops the service and removes the unit — but only one that `--init-enable` wrote; it will not touch a unit installed by hand or by the `.deb` package.
+
+For user scope, enable lingering so the service starts at boot without a login: `loginctl enable-linger $USER`.
+
+### Manual setup
+
 An example unit file is provided at [`examples/nextcloud-sync-daemon.service`](examples/nextcloud-sync-daemon.service).
 
-### System-wide service
+#### System-wide service
 
 ```bash
 sudo cp nextcloud-sync-daemon.service /etc/systemd/system/
@@ -147,7 +164,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now nextcloud-sync-daemon
 ```
 
-### User service (no root required)
+#### User service (no root required)
 
 ```bash
 mkdir -p ~/.config/systemd/user

--- a/cmd/nextcloud-sync-daemon/main.go
+++ b/cmd/nextcloud-sync-daemon/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/graemejross/nextcloud-sync-daemon/internal/notifypush"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/peer"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/poller"
+	"github.com/graemejross/nextcloud-sync-daemon/internal/svcinit"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/sync"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/watcher"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/webhook"
@@ -39,6 +40,8 @@ func run() int {
 		validate    bool
 		showVersion bool
 		test        bool
+		initEnable  bool
+		initDisable bool
 	)
 
 	flag.StringVar(&configPath, "config", "", "path to config file")
@@ -46,10 +49,21 @@ func run() int {
 	flag.BoolVar(&test, "test", false, "write a marker file, sync, report latency, clean up, and exit")
 	flag.BoolVar(&validate, "validate", false, "validate config and exit")
 	flag.BoolVar(&showVersion, "version", false, "print version and exit")
+	flag.BoolVar(&initEnable, "init-enable", false, "register and start the daemon as a systemd service (system scope as root, user scope otherwise) and exit")
+	flag.BoolVar(&initDisable, "init-disable", false, "stop and remove the systemd service registration created by --init-enable and exit")
 	flag.Parse()
 
 	if showVersion {
 		fmt.Printf("nextcloud-sync-daemon %s\n", version)
+		return 0
+	}
+
+	// --init-disable needs no config — it only undoes a prior --init-enable.
+	if initDisable {
+		if err := svcinit.Disable(svcinit.CurrentScope(), userHomeOrDie(), svcinit.ExecRunner{}, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
 		return 0
 	}
 
@@ -69,6 +83,34 @@ func run() int {
 
 	if validate {
 		fmt.Printf("config %s is valid\n", cfgPath)
+		return 0
+	}
+
+	// --init-enable requires a valid config (loaded above) so we never
+	// register a service that fails at startup. The unit embeds the
+	// resolved binary and config paths, and grants write access to the
+	// configured sync directory.
+	if initEnable {
+		binPath, err := os.Executable()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: resolving own binary path: %v\n", err)
+			return 1
+		}
+		absCfg, err := filepath.Abs(cfgPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: resolving config path: %v\n", err)
+			return 1
+		}
+		opts := svcinit.Options{
+			Scope:      svcinit.CurrentScope(),
+			BinaryPath: binPath,
+			ConfigPath: absCfg,
+			LocalDir:   cfg.Sync.LocalDir,
+		}
+		if err := svcinit.Enable(opts, userHomeOrDie(), svcinit.ExecRunner{}, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
 		return 0
 	}
 
@@ -245,6 +287,18 @@ func run() int {
 	_, _ = sdnotify.SdNotify(false, sdnotify.SdNotifyStopping)
 	logger.Info("daemon stopped")
 	return 0
+}
+
+// userHomeOrDie returns the home directory, exiting on failure — callers
+// only need it for the user-scope unit path, and without a home there is
+// no user scope to manage.
+func userHomeOrDie() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: resolving home directory: %v\n", err)
+		os.Exit(1)
+	}
+	return home
 }
 
 func setupLogging(cfg *config.Config) *slog.Logger {

--- a/internal/svcinit/svcinit.go
+++ b/internal/svcinit/svcinit.go
@@ -1,0 +1,201 @@
+// Package svcinit registers the daemon as a systemd service (--init-enable)
+// and removes that registration (--init-disable). Refs #35.
+//
+// Scope follows the invoking user: uid 0 installs a system-scope unit under
+// /etc/systemd/system and enables it system-wide; any other uid installs a
+// user-scope unit under ~/.config/systemd/user. Only units at those exact
+// paths are managed — --init-disable refuses to touch a unit it did not
+// write (e.g. one installed by the .deb package under /usr/lib/systemd).
+package svcinit
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// UnitName is the systemd unit filename managed by this package.
+const UnitName = "nextcloud-sync-daemon.service"
+
+// Scope is the systemd scope a unit is installed into.
+type Scope string
+
+const (
+	ScopeSystem Scope = "system"
+	ScopeUser   Scope = "user"
+)
+
+// CurrentScope returns the scope for the invoking user: system for uid 0,
+// user otherwise.
+func CurrentScope() Scope {
+	if os.Geteuid() == 0 {
+		return ScopeSystem
+	}
+	return ScopeUser
+}
+
+// Options describes the unit to generate.
+type Options struct {
+	Scope      Scope
+	BinaryPath string // absolute path written into ExecStart
+	ConfigPath string // absolute path passed to --config
+	LocalDir   string // sync directory, granted write access via ReadWritePaths
+}
+
+// Runner executes systemctl. Indirection for tests.
+type Runner interface {
+	Run(name string, args ...string) error
+}
+
+// ExecRunner runs commands for real, inheriting stdout/stderr so systemctl
+// output reaches the user.
+type ExecRunner struct{}
+
+func (ExecRunner) Run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// UnitPath returns where the managed unit lives for the given scope.
+// home is only used for user scope.
+func UnitPath(scope Scope, home string) string {
+	if scope == ScopeSystem {
+		return filepath.Join("/etc/systemd/system", UnitName)
+	}
+	return filepath.Join(home, ".config", "systemd", "user", UnitName)
+}
+
+// UnitContent renders the unit file for the given options.
+//
+// The system-scope unit carries the same hardening as the packaged unit,
+// with ReadWritePaths filled in from the validated config so the service
+// starts without a manual drop-in. The user-scope unit omits the sandboxing
+// directives: several of them (ProtectSystem, ProtectProc) need privileges
+// or unprivileged user namespaces that are not uniformly available to user
+// managers, and ProtectHome would block the common case of syncing a
+// directory under $HOME.
+func UnitContent(o Options) string {
+	var b strings.Builder
+	b.WriteString("# Installed by nextcloud-sync-daemon --init-enable (Refs #35).\n")
+	b.WriteString("# Remove with nextcloud-sync-daemon --init-disable.\n")
+	b.WriteString("\n[Unit]\n")
+	b.WriteString("Description=Nextcloud Sync Daemon\n")
+	b.WriteString("After=network-online.target\n")
+	b.WriteString("Wants=network-online.target\n")
+	b.WriteString("\n[Service]\n")
+	b.WriteString("Type=notify\n")
+	fmt.Fprintf(&b, "ExecStart=%s --config %s\n", o.BinaryPath, o.ConfigPath)
+	b.WriteString("Restart=on-failure\n")
+	b.WriteString("RestartSec=5\n")
+	b.WriteString("WatchdogSec=1800\n")
+	if o.Scope == ScopeSystem {
+		b.WriteString("\n# Security hardening (system scope)\n")
+		b.WriteString("NoNewPrivileges=yes\n")
+		b.WriteString("ProtectSystem=strict\n")
+		fmt.Fprintf(&b, "ReadWritePaths=%s\n", o.LocalDir)
+		b.WriteString("PrivateTmp=yes\n")
+		b.WriteString("ProtectProc=invisible\n")
+	}
+	b.WriteString("\n[Install]\n")
+	if o.Scope == ScopeSystem {
+		b.WriteString("WantedBy=multi-user.target\n")
+	} else {
+		b.WriteString("WantedBy=default.target\n")
+	}
+	return b.String()
+}
+
+// systemctl returns the systemctl argument prefix for the scope.
+func systemctlArgs(scope Scope, args ...string) []string {
+	if scope == ScopeUser {
+		return append([]string{"--user"}, args...)
+	}
+	return args
+}
+
+// Enable writes the unit file and enables + starts the service. It refuses
+// to overwrite an existing unit at the managed path.
+func Enable(o Options, home string, r Runner, out io.Writer) error {
+	unitPath := UnitPath(o.Scope, home)
+
+	if _, err := os.Stat(unitPath); err == nil {
+		return fmt.Errorf("unit already exists at %s — run --init-disable first, or edit the existing unit", unitPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking %s: %w", unitPath, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0755); err != nil {
+		return fmt.Errorf("creating unit directory: %w", err)
+	}
+
+	// O_EXCL closes the race between the Stat above and the write.
+	f, err := os.OpenFile(unitPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("writing unit file: %w", err)
+	}
+	if _, err := f.WriteString(UnitContent(o)); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("writing unit file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("writing unit file: %w", err)
+	}
+	fmt.Fprintf(out, "wrote %s\n", unitPath)
+
+	if err := r.Run("systemctl", systemctlArgs(o.Scope, "daemon-reload")...); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w", err)
+	}
+	if err := r.Run("systemctl", systemctlArgs(o.Scope, "enable", "--now", UnitName)...); err != nil {
+		return fmt.Errorf("systemctl enable --now: %w", err)
+	}
+	fmt.Fprintf(out, "enabled and started %s (%s scope)\n", UnitName, o.Scope)
+
+	if o.Scope == ScopeUser {
+		fmt.Fprintln(out, "note: user-scope services stop at logout unless lingering is on — run: loginctl enable-linger $USER")
+	}
+	return nil
+}
+
+// Disable stops + disables the service and removes the unit file, but only
+// if the unit at the managed path was written by Enable (identified by the
+// marker comment). A missing unit file is not an error — the disable calls
+// still run so a half-removed state converges.
+func Disable(scope Scope, home string, r Runner, out io.Writer) error {
+	unitPath := UnitPath(scope, home)
+
+	content, err := os.ReadFile(unitPath)
+	unitExists := err == nil
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("reading %s: %w", unitPath, err)
+	}
+	if unitExists && !strings.Contains(string(content), "--init-enable") {
+		return fmt.Errorf("unit at %s was not installed by --init-enable — remove it yourself if that is what you want", unitPath)
+	}
+
+	if err := r.Run("systemctl", systemctlArgs(scope, "disable", "--now", UnitName)...); err != nil {
+		// The unit may already be gone from systemd's view; report but continue
+		// so the file still gets removed.
+		fmt.Fprintf(out, "warning: systemctl disable --now failed: %v\n", err)
+	}
+
+	if unitExists {
+		if err := os.Remove(unitPath); err != nil {
+			return fmt.Errorf("removing unit file: %w", err)
+		}
+		fmt.Fprintf(out, "removed %s\n", unitPath)
+	} else {
+		fmt.Fprintf(out, "no unit file at %s\n", unitPath)
+	}
+
+	if err := r.Run("systemctl", systemctlArgs(scope, "daemon-reload")...); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w", err)
+	}
+	fmt.Fprintf(out, "disabled %s (%s scope)\n", UnitName, scope)
+	return nil
+}

--- a/internal/svcinit/svcinit_test.go
+++ b/internal/svcinit/svcinit_test.go
@@ -1,0 +1,216 @@
+package svcinit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeRunner records systemctl invocations.
+type fakeRunner struct {
+	calls [][]string
+	err   error
+}
+
+func (f *fakeRunner) Run(name string, args ...string) error {
+	f.calls = append(f.calls, append([]string{name}, args...))
+	return f.err
+}
+
+func testOptions(scope Scope) Options {
+	return Options{
+		Scope:      scope,
+		BinaryPath: "/usr/local/bin/nextcloud-sync-daemon",
+		ConfigPath: "/etc/nextcloud-sync-daemon/config.yaml",
+		LocalDir:   "/srv/nextcloud-sync",
+	}
+}
+
+func TestUnitContentSystem(t *testing.T) {
+	c := UnitContent(testOptions(ScopeSystem))
+
+	for _, want := range []string{
+		"ExecStart=/usr/local/bin/nextcloud-sync-daemon --config /etc/nextcloud-sync-daemon/config.yaml",
+		"Type=notify",
+		"ProtectSystem=strict",
+		"ReadWritePaths=/srv/nextcloud-sync",
+		"ProtectProc=invisible",
+		"WantedBy=multi-user.target",
+		"--init-enable", // marker Disable checks for
+	} {
+		if !strings.Contains(c, want) {
+			t.Errorf("system unit missing %q:\n%s", want, c)
+		}
+	}
+	if strings.Contains(c, "ProtectHome") {
+		t.Error("system unit must not set ProtectHome — the sync dir may live under /home")
+	}
+}
+
+func TestUnitContentUser(t *testing.T) {
+	c := UnitContent(testOptions(ScopeUser))
+
+	for _, want := range []string{
+		"ExecStart=/usr/local/bin/nextcloud-sync-daemon --config /etc/nextcloud-sync-daemon/config.yaml",
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(c, want) {
+			t.Errorf("user unit missing %q:\n%s", want, c)
+		}
+	}
+	// Sandboxing directives are system-scope only.
+	for _, banned := range []string{"ProtectSystem", "ReadWritePaths", "ProtectProc", "PrivateTmp"} {
+		if strings.Contains(c, banned) {
+			t.Errorf("user unit must not contain %q:\n%s", banned, c)
+		}
+	}
+}
+
+func TestUnitPath(t *testing.T) {
+	if got := UnitPath(ScopeSystem, "/home/x"); got != "/etc/systemd/system/nextcloud-sync-daemon.service" {
+		t.Errorf("system path = %s", got)
+	}
+	if got := UnitPath(ScopeUser, "/home/x"); got != "/home/x/.config/systemd/user/nextcloud-sync-daemon.service" {
+		t.Errorf("user path = %s", got)
+	}
+}
+
+func TestEnableWritesUnitAndRunsSystemctl(t *testing.T) {
+	home := t.TempDir()
+	r := &fakeRunner{}
+	var out strings.Builder
+
+	if err := Enable(testOptions(ScopeUser), home, r, &out); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+
+	unit := UnitPath(ScopeUser, home)
+	data, err := os.ReadFile(unit)
+	if err != nil {
+		t.Fatalf("unit not written: %v", err)
+	}
+	if !strings.Contains(string(data), "ExecStart=") {
+		t.Error("unit content missing ExecStart")
+	}
+
+	want := [][]string{
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "enable", "--now", UnitName},
+	}
+	if len(r.calls) != len(want) {
+		t.Fatalf("systemctl calls = %v", r.calls)
+	}
+	for i := range want {
+		if strings.Join(r.calls[i], " ") != strings.Join(want[i], " ") {
+			t.Errorf("call %d = %v, want %v", i, r.calls[i], want[i])
+		}
+	}
+	if !strings.Contains(out.String(), "enable-linger") {
+		t.Error("user-scope enable should mention loginctl enable-linger")
+	}
+}
+
+func TestEnableSystemScopeCallsPlainSystemctl(t *testing.T) {
+	// System scope must not pass --user. Unit path is under /etc, so run
+	// Enable against a home dir anyway and intercept before the file write
+	// by pre-creating the path? Not possible without root — so test the
+	// argument builder directly.
+	got := systemctlArgs(ScopeSystem, "enable", "--now", UnitName)
+	if strings.Join(got, " ") != "enable --now "+UnitName {
+		t.Errorf("system args = %v", got)
+	}
+	gotUser := systemctlArgs(ScopeUser, "daemon-reload")
+	if strings.Join(gotUser, " ") != "--user daemon-reload" {
+		t.Errorf("user args = %v", gotUser)
+	}
+}
+
+func TestEnableRefusesOverwrite(t *testing.T) {
+	home := t.TempDir()
+	unit := UnitPath(ScopeUser, home)
+	if err := os.MkdirAll(filepath.Dir(unit), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unit, []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &fakeRunner{}
+	err := Enable(testOptions(ScopeUser), home, r, &strings.Builder{})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already-exists error, got %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("systemctl must not run when refusing: %v", r.calls)
+	}
+	data, _ := os.ReadFile(unit)
+	if string(data) != "existing" {
+		t.Error("existing unit was modified")
+	}
+}
+
+func TestDisableRemovesManagedUnit(t *testing.T) {
+	home := t.TempDir()
+	r := &fakeRunner{}
+	if err := Enable(testOptions(ScopeUser), home, r, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	r.calls = nil
+
+	if err := Disable(ScopeUser, home, r, &strings.Builder{}); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if _, err := os.Stat(UnitPath(ScopeUser, home)); !os.IsNotExist(err) {
+		t.Error("unit file not removed")
+	}
+
+	want := [][]string{
+		{"systemctl", "--user", "disable", "--now", UnitName},
+		{"systemctl", "--user", "daemon-reload"},
+	}
+	for i := range want {
+		if strings.Join(r.calls[i], " ") != strings.Join(want[i], " ") {
+			t.Errorf("call %d = %v, want %v", i, r.calls[i], want[i])
+		}
+	}
+}
+
+func TestDisableRefusesForeignUnit(t *testing.T) {
+	home := t.TempDir()
+	unit := UnitPath(ScopeUser, home)
+	if err := os.MkdirAll(filepath.Dir(unit), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unit, []byte("[Unit]\nDescription=someone else's\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &fakeRunner{}
+	err := Disable(ScopeUser, home, r, &strings.Builder{})
+	if err == nil || !strings.Contains(err.Error(), "not installed by --init-enable") {
+		t.Fatalf("expected foreign-unit refusal, got %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("systemctl must not run when refusing: %v", r.calls)
+	}
+	if _, statErr := os.Stat(unit); statErr != nil {
+		t.Error("foreign unit must not be removed")
+	}
+}
+
+func TestDisableMissingUnitStillConverges(t *testing.T) {
+	home := t.TempDir()
+	r := &fakeRunner{}
+	var out strings.Builder
+
+	if err := Disable(ScopeUser, home, r, &out); err != nil {
+		t.Fatalf("Disable with no unit: %v", err)
+	}
+	if len(r.calls) != 2 {
+		t.Errorf("expected disable + daemon-reload to still run: %v", r.calls)
+	}
+	if !strings.Contains(out.String(), "no unit file") {
+		t.Errorf("output should say no unit file: %s", out.String())
+	}
+}


### PR DESCRIPTION
Implements #35 as discussed on the issue.

- `--init-enable`: uid 0 → system unit in `/etc/systemd/system` + `systemctl enable --now`; otherwise → user unit in `~/.config/systemd/user` + `systemctl --user enable --now` with a `loginctl enable-linger` reminder.
- Unit is generated, embedding the resolved binary and config paths; system scope carries the packaged unit's hardening with `ReadWritePaths` filled from the validated config (no manual drop-in needed, unlike the .deb unit which cannot know the sync dir).
- Config is validated before anything is written.
- Refuses to overwrite an existing unit (`O_EXCL`).
- `--init-disable` removes only a unit carrying the `--init-enable` marker; hand-installed and package units are refused. Missing unit converges rather than erroring.

## Verification

- `make test` clean, `-race`, all packages; new svcinit package 76.2% coverage (unit content per scope, path resolution, both refusal paths, systemctl call sequences via fake runner).
- End-to-end with the real binary, isolated `HOME`, stub `systemctl` on PATH: enable wrote the unit (correct ExecStart/WantedBy), invoked `--user daemon-reload` then `enable --now`; second enable refused with exit 1; disable removed the unit and re-reloaded. Host's live daemon untouched.
- `gofmt` clean on all touched files (two pre-existing unformatted files on main left alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqHttn5PvNJ5MejyzABLJa