### PR TITLE
Add --get-app-password via Login Flow v2 (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ poll:
 
 Use a [Nextcloud app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#manage-connected-browsers-and-devices) rather than the main account password.
 
+The daemon can obtain one for you without a browser on this machine, using the same [Login Flow v2](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/) as the desktop client. It prints a URL; open it in a browser on any device (your phone works), log in, approve — the CLI picks up the generated app password and prints it to stdout, everything else to stderr:
+
+```bash
+sudo mkdir -p /etc/nextcloud-sync-daemon
+nextcloud-sync-daemon --get-app-password --server https://cloud.example.com \
+  | sudo tee /etc/nextcloud-sync-daemon/password > /dev/null
+sudo chmod 600 /etc/nextcloud-sync-daemon/password
+```
+
+(`--server` can be omitted once `server.url` is configured.) This works with two-factor accounts, since the login happens in the browser. Or create the app password manually in the Nextcloud web UI and write the file yourself:
+
 ```bash
 sudo mkdir -p /etc/nextcloud-sync-daemon
 echo "your-app-password" | sudo tee /etc/nextcloud-sync-daemon/password > /dev/null

--- a/cmd/nextcloud-sync-daemon/main.go
+++ b/cmd/nextcloud-sync-daemon/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	sdnotify "github.com/coreos/go-systemd/v22/daemon"
+	"github.com/graemejross/nextcloud-sync-daemon/internal/appauth"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/config"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/daemon"
 	"github.com/graemejross/nextcloud-sync-daemon/internal/engine"
@@ -42,6 +43,8 @@ func run() int {
 		test        bool
 		initEnable  bool
 		initDisable bool
+		getAppPass  bool
+		serverURL   string
 	)
 
 	flag.StringVar(&configPath, "config", "", "path to config file")
@@ -51,6 +54,8 @@ func run() int {
 	flag.BoolVar(&showVersion, "version", false, "print version and exit")
 	flag.BoolVar(&initEnable, "init-enable", false, "register and start the daemon as a systemd service (system scope as root, user scope otherwise) and exit")
 	flag.BoolVar(&initDisable, "init-disable", false, "stop and remove the systemd service registration created by --init-enable and exit")
+	flag.BoolVar(&getAppPass, "get-app-password", false, "obtain a Nextcloud app password via Login Flow v2 (browser on any device) and exit")
+	flag.StringVar(&serverURL, "server", "", "Nextcloud server URL for --get-app-password (default: server.url from config)")
 	flag.Parse()
 
 	if showVersion {
@@ -65,6 +70,13 @@ func run() int {
 			return 1
 		}
 		return 0
+	}
+
+	// --get-app-password runs before config validation: it exists precisely
+	// for first-run setups where no valid config exists yet. --server wins;
+	// otherwise the server URL is read from the config if one resolves.
+	if getAppPass {
+		return runGetAppPassword(serverURL, configPath)
 	}
 
 	// Find config file
@@ -286,6 +298,52 @@ func run() int {
 
 	_, _ = sdnotify.SdNotify(false, sdnotify.SdNotifyStopping)
 	logger.Info("daemon stopped")
+	return 0
+}
+
+// runGetAppPassword drives Login Flow v2 (Refs #37). Everything
+// informational goes to stderr; stdout carries only the app password, so
+// the output can be redirected straight into a password file:
+//
+//	nextcloud-sync-daemon --get-app-password > password && chmod 600 password
+func runGetAppPassword(serverURL, configPath string) int {
+	if serverURL == "" {
+		// Best-effort config read — the config may be absent (first run) or
+		// invalid (sync dir not created yet); only server.url is needed.
+		if cfgPath, err := config.FindConfigPath(configPath); err == nil {
+			if cfg, err := config.Load(cfgPath); err == nil {
+				serverURL = cfg.Server.URL
+			}
+		}
+	}
+	if serverURL == "" {
+		fmt.Fprintln(os.Stderr, "error: no server URL — pass --server https://cloud.example.com or configure server.url")
+		return 1
+	}
+
+	ctx, stop := makeContext()
+	defer stop()
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	ua := "nextcloud-sync-daemon/" + version
+
+	flow, err := appauth.Start(ctx, client, serverURL, ua)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(os.Stderr, "Open this URL in a browser on any device and log in:\n\n    %s\n\n", flow.LoginURL)
+	fmt.Fprintln(os.Stderr, "Waiting for approval (valid 20 minutes, Ctrl-C to abort)...")
+
+	creds, err := flow.Poll(ctx, client, 5*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(os.Stderr, "Approved as %s. The app password (below on stdout) is shown once — store it in your password_file with mode 600.\n", creds.LoginName)
+	fmt.Println(creds.AppPassword)
 	return 0
 }
 

--- a/internal/appauth/appauth.go
+++ b/internal/appauth/appauth.go
@@ -1,0 +1,149 @@
+// Package appauth obtains a Nextcloud app password via Login Flow v2
+// (--get-app-password). Refs #37.
+//
+// The flow is the one the desktop client uses, designed for headless
+// clients: the CLI POSTs to /index.php/login/v2 and receives a login URL
+// plus a poll token. The user opens the login URL in a browser on any
+// device — never this machine — and approves. The CLI polls until the
+// server releases the credentials, then prints the app password.
+//
+// See https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/
+package appauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Flow is a started Login Flow v2 session.
+type Flow struct {
+	// LoginURL is opened by the user in a browser on any device.
+	LoginURL string
+	// pollEndpoint + pollToken drive the poll loop.
+	pollEndpoint string
+	pollToken    string
+}
+
+// Credentials is the result of an approved login flow.
+type Credentials struct {
+	Server      string `json:"server"`
+	LoginName   string `json:"loginName"`
+	AppPassword string `json:"appPassword"`
+}
+
+// tokenValidity is how long the server keeps the poll token alive.
+const tokenValidity = 20 * time.Minute
+
+// Start begins a Login Flow v2 session against serverURL. userAgent names
+// the resulting app password in the Nextcloud security settings.
+func Start(ctx context.Context, client *http.Client, serverURL, userAgent string) (*Flow, error) {
+	endpoint := strings.TrimRight(serverURL, "/") + "/index.php/login/v2"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("starting login flow: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("starting login flow: server returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var parsed struct {
+		Poll struct {
+			Token    string `json:"token"`
+			Endpoint string `json:"endpoint"`
+		} `json:"poll"`
+		Login string `json:"login"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("parsing login flow response: %w", err)
+	}
+	if parsed.Login == "" || parsed.Poll.Endpoint == "" || parsed.Poll.Token == "" {
+		return nil, errors.New("login flow response missing login URL or poll endpoint — is this a Nextcloud server?")
+	}
+
+	return &Flow{
+		LoginURL:     parsed.Login,
+		pollEndpoint: parsed.Poll.Endpoint,
+		pollToken:    parsed.Poll.Token,
+	}, nil
+}
+
+// Poll waits for the user to approve the login in their browser. It polls
+// every interval until the server releases the credentials, the token
+// expires (20 minutes), or ctx is cancelled. The server answers 404 until
+// approval, then 200 exactly once.
+func (f *Flow) Poll(ctx context.Context, client *http.Client, interval time.Duration) (*Credentials, error) {
+	deadline := time.Now().Add(tokenValidity)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+
+		if time.Now().After(deadline) {
+			return nil, errors.New("login not approved within 20 minutes — the token has expired, run the command again")
+		}
+
+		creds, done, err := f.pollOnce(ctx, client)
+		if err != nil {
+			return nil, err
+		}
+		if done {
+			return creds, nil
+		}
+	}
+}
+
+// pollOnce performs a single poll. done=false means not yet approved.
+func (f *Flow) pollOnce(ctx context.Context, client *http.Client) (*Credentials, bool, error) {
+	form := url.Values{"token": {f.pollToken}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.pollEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, false, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Transient network failure — keep polling rather than aborting a
+		// flow the user may be mid-way through approving.
+		return nil, false, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return nil, false, nil // not approved yet
+	case http.StatusOK:
+		var creds Credentials
+		if err := json.NewDecoder(resp.Body).Decode(&creds); err != nil {
+			return nil, false, fmt.Errorf("parsing credentials: %w", err)
+		}
+		if creds.AppPassword == "" {
+			return nil, false, errors.New("server returned 200 but no app password")
+		}
+		return &creds, true, nil
+	default:
+		return nil, false, fmt.Errorf("poll endpoint returned %s", resp.Status)
+	}
+}

--- a/internal/appauth/appauth_test.go
+++ b/internal/appauth/appauth_test.go
@@ -1,0 +1,131 @@
+package appauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeServer implements the two Login Flow v2 endpoints. approveAfter is the
+// number of 404 polls before the credentials are released.
+func fakeServer(t *testing.T, approveAfter int32) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var polls atomic.Int32
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+
+	mux.HandleFunc("/index.php/login/v2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"poll": map[string]string{
+				"token":    "test-token",
+				"endpoint": srv.URL + "/login/v2/poll",
+			},
+			"login": srv.URL + "/login/v2/flow/abc",
+		})
+	})
+
+	mux.HandleFunc("/login/v2/poll", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil || r.PostForm.Get("token") != "test-token" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if polls.Add(1) <= approveAfter {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Credentials{
+			Server:      srv.URL,
+			LoginName:   "sync-user",
+			AppPassword: "generated-app-password",
+		})
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &polls
+}
+
+func TestStartParsesFlow(t *testing.T) {
+	srv, _ := fakeServer(t, 0)
+
+	f, err := Start(context.Background(), srv.Client(), srv.URL+"/", "nextcloud-sync-daemon test")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if f.LoginURL != srv.URL+"/login/v2/flow/abc" {
+		t.Errorf("LoginURL = %s", f.LoginURL)
+	}
+	if f.pollEndpoint != srv.URL+"/login/v2/poll" || f.pollToken != "test-token" {
+		t.Errorf("poll = %s token = %s", f.pollEndpoint, f.pollToken)
+	}
+}
+
+func TestStartRejectsNonNextcloud(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	_, err := Start(context.Background(), srv.Client(), srv.URL, "ua")
+	if err == nil {
+		t.Fatal("expected error for empty flow response")
+	}
+}
+
+func TestStartSurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not here", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := Start(context.Background(), srv.Client(), srv.URL, "ua")
+	if err == nil {
+		t.Fatal("expected error for 404 on flow start")
+	}
+}
+
+func TestPollWaitsForApproval(t *testing.T) {
+	srv, polls := fakeServer(t, 3)
+
+	f, err := Start(context.Background(), srv.Client(), srv.URL, "ua")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := f.Poll(context.Background(), srv.Client(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if creds.AppPassword != "generated-app-password" || creds.LoginName != "sync-user" {
+		t.Errorf("creds = %+v", creds)
+	}
+	if got := polls.Load(); got < 4 {
+		t.Errorf("expected at least 4 polls (3 pending + 1 approved), got %d", got)
+	}
+}
+
+func TestPollHonoursContextCancel(t *testing.T) {
+	srv, _ := fakeServer(t, 1<<30) // never approves
+
+	f, err := Start(context.Background(), srv.Client(), srv.URL, "ua")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = f.Poll(ctx, srv.Client(), time.Millisecond)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+}


### PR DESCRIPTION
Implements the helper discussed on #37.

- `--get-app-password [--server URL]`: starts Login Flow v2, prints the login URL (open in a browser on any device — never this machine), polls until approved, prints the app password to stdout and everything else to stderr, so it pipes straight into a password file.
- `--server` falls back to `server.url` from the config when one resolves; the read is deliberately best-effort because the flag exists for first-run setups with no valid config yet.
- Works with 2FA accounts (the login happens in the browser). Token validity 20 minutes; transient poll failures keep polling.
- README's password-file section now leads with this flow.

## Verification

- `make test` clean, `-race`, all packages. New `appauth` tests: flow parsing, non-Nextcloud response, HTTP error, 404-until-approved poll loop, context cancellation (httptest).
- End-to-end with the real binary against a local fake implementing both endpoints: two 404 polls then approval, exit 0, stdout exactly the app password.
- Endpoint shapes verified against the Nextcloud developer manual (Login Flow v2 page) earlier today on #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqHttn5PvNJ5MejyzABLJa